### PR TITLE
Close duplex resource streams half if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .php_cs.cache
 build
+coverage
 composer.lock
 phpunit.xml
 vendor

--- a/lib/ResourceInputStream.php
+++ b/lib/ResourceInputStream.php
@@ -6,6 +6,7 @@ use Amp\Deferred;
 use Amp\Failure;
 use Amp\Loop;
 use Amp\Promise;
+use Amp\Success;
 
 class ResourceInputStream implements InputStream {
     const DEFAULT_CHUNK_SIZE = 8192;
@@ -89,7 +90,7 @@ class ResourceInputStream implements InputStream {
         }
 
         if (!$this->readable) {
-            return new Failure(new ClosedException("The stream has been closed"));
+            return new Success(null);
         }
 
         $this->deferred = new Deferred;
@@ -112,7 +113,11 @@ class ResourceInputStream implements InputStream {
         }
 
         if ($this->autoClose && \is_resource($this->resource)) {
-            @\fclose($this->resource);
+            if (\substr(\stream_get_meta_data($this->resource)["stream_type"], 0, \strlen("tcp_socket"))  === "tcp_socket") {
+                \stream_socket_shutdown($this->resource, \STREAM_SHUT_RD);
+            } else {
+                @\fclose($this->resource);
+            }
         }
 
         $this->resource = null;

--- a/lib/ResourceInputStream.php
+++ b/lib/ResourceInputStream.php
@@ -3,7 +3,6 @@
 namespace Amp\ByteStream;
 
 use Amp\Deferred;
-use Amp\Failure;
 use Amp\Loop;
 use Amp\Promise;
 use Amp\Success;

--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -188,7 +188,11 @@ class ResourceOutputStream implements OutputStream {
         }
 
         if (\is_resource($this->resource)) {
-            @\fclose($this->resource);
+            if (\substr(\stream_get_meta_data($this->resource)["stream_type"], 0, \strlen("tcp_socket"))  === "tcp_socket") {
+                \stream_socket_shutdown($this->resource, \STREAM_SHUT_WR);
+            } else {
+                @\fclose($this->resource);
+            }
         }
 
         $this->resource = null;

--- a/test/ResourceInputStreamTest.php
+++ b/test/ResourceInputStreamTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Amp\ByteStream\Test;
+
+use Amp\ByteStream\ResourceInputStream;
+use Amp\PHPUnit\TestCase;
+
+class ResourceInputStreamTest extends TestCase {
+    public function testCloseOnUniFileStream() {
+        $resource = \fopen(__FILE__, "r");
+        $stream = new ResourceInputStream($resource);
+
+        $stream->close();
+
+        $result = 42;
+
+        $stream->read()->onResolve(function ($e, $r) use (&$result) {
+            $this->assertNull($e);
+            $result = $r;
+        });
+
+        $this->assertNull($result);
+        $this->assertFalse(@\fread($resource, 8192));
+    }
+
+    public function testCloseOnDuplexFileStream() {
+        $resource = \fopen(__FILE__, "a+");
+        $stream = new ResourceInputStream($resource);
+
+        $stream->close();
+
+        $result = 42;
+
+        $stream->read()->onResolve(function ($e, $r) use (&$result) {
+            $this->assertNull($e);
+            $result = $r;
+        });
+
+        $this->assertNull($result);
+        $this->assertFalse(@\fread($resource, 8192));
+
+        // Files do not support half-closes
+        $this->assertFalse(@\fwrite($resource, "foobar"));
+    }
+
+    public function testCloseOnTcpStream() {
+        $resource = \stream_socket_client("tcp://github.com:80", $errno, $errstr, 10, \STREAM_CLIENT_CONNECT);
+
+        $this->assertSame(0, $errno);
+        $this->assertSame("", $errstr);
+        $this->assertInternalType("resource", $resource);
+
+        $stream = new ResourceInputStream($resource);
+        $stream->close();
+
+        $result = 42;
+
+        $stream->read()->onResolve(function ($e, $r) use (&$result) {
+            $this->assertNull($e);
+            $result = $r;
+        });
+
+        $this->assertNull($result);
+        $this->assertSame("", \fread($resource, 8192));
+
+        // Tcp does support half-closes
+        $this->assertNotFalse(@\fwrite($resource, "foobar"));
+    }
+}


### PR DESCRIPTION
This allows `Socket` to use half-closing.