### PR TITLE
Make Message accept an InputStream instead of an Iterator

### DIFF
--- a/lib/IteratorStream.php
+++ b/lib/IteratorStream.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Amp\ByteStream;
+
+use Amp\Deferred;
+use Amp\Iterator;
+use Amp\Promise;
+
+class IteratorStream implements InputStream {
+    private $iterator;
+
+    public function __construct(Iterator $iterator) {
+        $this->iterator = $iterator;
+    }
+
+    /** @inheritdoc */
+    public function read(): Promise {
+        $deferred = new Deferred;
+
+        $this->iterator->advance()->onResolve(function ($error, $hasNextElement) use ($deferred) {
+            if ($error) {
+                $deferred->fail($error);
+            } elseif ($hasNextElement) {
+                $deferred->resolve($this->iterator->getCurrent());
+            } else {
+                $deferred->resolve(null);
+            }
+        });
+
+        return $deferred->promise();
+    }
+}

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -2,6 +2,7 @@
 
 namespace Amp\ByteStream\Test;
 
+use Amp\ByteStream\IteratorStream;
 use Amp\ByteStream\Message;
 use Amp\Emitter;
 use Amp\Loop;
@@ -13,7 +14,7 @@ class MessageTest extends TestCase {
             $values = ["abc", "def", "ghi"];
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             foreach ($values as $value) {
                 $emitter->emit($value);
@@ -30,7 +31,7 @@ class MessageTest extends TestCase {
             $values = ["abc", "def", "ghi"];
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             foreach ($values as $value) {
                 $emitter->emit($value);
@@ -55,7 +56,7 @@ class MessageTest extends TestCase {
             $values = ["abc", "def", "ghi"];
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             foreach ($values as $value) {
                 $emitter->emit($value);
@@ -78,7 +79,7 @@ class MessageTest extends TestCase {
             $values = ["abc", "def", "ghi"];
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             foreach ($values as $value) {
                 $emitter->emit($value);
@@ -95,7 +96,7 @@ class MessageTest extends TestCase {
             $values = ["abc", "def", "ghi"];
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             $emitter->emit($values[0]);
 
@@ -119,7 +120,7 @@ class MessageTest extends TestCase {
             $value = "abc";
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             $emitter->emit($value);
             $emitter->fail($exception);
@@ -138,7 +139,7 @@ class MessageTest extends TestCase {
         Loop::run(function () {
             $emitter = new Emitter;
             $emitter->complete();
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             $this->assertNull(yield $stream->read());
         });
@@ -149,7 +150,7 @@ class MessageTest extends TestCase {
             $value = "abc";
 
             $emitter = new Emitter;
-            $stream = new Message($emitter->iterate());
+            $stream = new Message(new IteratorStream($emitter->iterate()));
 
             $emitter->emit($value);
             $emitter->complete();


### PR DESCRIPTION
The purpose of Message is to allow streaming and buffering of an InputStream with a simple API. Before this commit, Message served a second purpose: Converting an Amp\Iterator to an InputStream. This has been separated to allow ZlibInputStream and other InputStreams to be used as Message. Converting an Amp\Iterator to an InputStream is now possible using the new IteratorStream class.