### PR TITLE
Anonymous function has an unused use $resource

### DIFF
--- a/lib/ResourceInputStream.php
+++ b/lib/ResourceInputStream.php
@@ -47,9 +47,8 @@ final class ResourceInputStream implements InputStream {
 
         $deferred = &$this->deferred;
         $readable = &$this->readable;
-        $resource = &$this->resource;
 
-        $this->watcher = Loop::onReadable($this->resource, static function ($watcher, $stream) use (&$deferred, &$readable, &$resource, $chunkSize) {
+        $this->watcher = Loop::onReadable($this->resource, static function ($watcher, $stream) use (&$deferred, &$readable, $chunkSize) {
             // Error reporting suppressed since fread() produces a warning if the stream has been shutdown
             $data = @\fread($stream, $chunkSize);
 


### PR DESCRIPTION
From 48c4e122d86bb1808b5ecb4659ba2e8165811fb1 the variable `$resource` is not used anymore in the anonymous function.