### PR TITLE
Implement Message::buffer(), deprecate direct Message::onResolve()

### DIFF
--- a/lib/SizeLimitException.php
+++ b/lib/SizeLimitException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Amp\ByteStream;
+
+class SizeLimitException extends StreamException {
+}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -32,3 +32,70 @@ function pipe(InputStream $source, OutputStream $destination): Promise {
         return $written;
     });
 }
+
+/**
+ * Buffers an input stream into a string.
+ *
+ * @param InputStream $stream Any input stream.
+ * @param int|null    $sizeLimit Maximum limit in bytes or `null` for no limit.
+ *
+ * @return Promise<string> Resolves to the buffered contents.
+ */
+function buffer(InputStream $stream, int $sizeLimit = null): Promise {
+    return call(function () use ($stream, $sizeLimit) {
+        $buffer = '';
+
+        // We don't need to check for the size each time if there's no limit.
+        if ($sizeLimit === null) {
+            while (null !== $chunk = yield $stream->read()) {
+                $buffer .= $chunk;
+                $chunk = ''; // free memory
+            }
+        } else {
+            while (null !== $chunk = yield $stream->read()) {
+                $buffer .= $chunk;
+                $chunk = ''; // free memory
+
+                if (\strlen($buffer) > $sizeLimit) {
+                    Promise\rethrow(discard($stream));
+
+                    throw new SizeLimitException(\sprintf(
+                        'The stream exceeded the specified limit of %d bytes; Read %d bytes',
+                        $sizeLimit,
+                        \strlen($buffer)
+                    ));
+                }
+            }
+        }
+
+        return $buffer;
+    });
+}
+
+/**
+ * Discards the remaining input stream.
+ *
+ * Before calling this function, you must ensure there's no pending read from that input stream.
+ *
+ * @param InputStream $stream Any input stream.
+ *
+ * @return Promise Resolves once the stream has been discarded.
+ *
+ * @throws PendingReadError If a previous read on the stream is still pending while starting the discard process.
+ */
+function discard(InputStream $stream): Promise {
+    return call(function () use ($stream) {
+        try {
+            while (null !== yield $stream->read()) {
+                // Discard unread bytes from message.
+            }
+        } catch (\Throwable $exception) {
+            // If exception is thrown here the connection closed anyway.
+
+            // We rethrow these, because the stream can't be discarded in that case.
+            if ($exception instanceof PendingReadError) {
+                throw $exception;
+            }
+        }
+    });
+}

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -12,6 +12,16 @@ use Amp\PHPUnit\TestCase;
 use Amp\PHPUnit\TestException;
 
 class MessageTest extends TestCase {
+    private $errorReporting;
+
+    public function setUp() {
+        $this->errorReporting = \error_reporting(\E_ALL ^ \E_USER_DEPRECATED);
+    }
+
+    public function tearDown() {
+        \error_reporting($this->errorReporting);
+    }
+
     public function testBufferingAll() {
         Loop::run(function () {
             $values = ["abc", "def", "ghi"];
@@ -146,7 +156,6 @@ class MessageTest extends TestCase {
     public function testFailingStreamWithPendingRead() {
         Loop::run(function () {
             $exception = new TestException;
-            $value = "abc";
 
             $emitter = new Emitter;
             $stream = new Message(new IteratorStream($emitter->iterate()));


### PR DESCRIPTION
Message implementing Promise has been discovered to be problematic. Direct use of onResolve() is now deprecated and should be replaced with Message::buffer(). Message will no longer implement Promise in a future version.

I think this is 100% backwards-compatible.