### PR TITLE
Polyfill STDOUT and STDERR on SAPIs not being CLI

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -12,6 +12,14 @@ if (\strlen('…') !== 3) {
     );
 } // @codeCoverageIgnoreEnd
 
+if (!\defined('STDOUT')) {
+    \define('STDOUT', \fopen('php://stdout', 'w'));
+}
+
+if (!\defined('STDERR')) {
+    \define('STDERR', \fopen('php://stderr', 'w'));
+}
+
 /**
  * @param \Amp\ByteStream\InputStream  $source
  * @param \Amp\ByteStream\OutputStream $destination


### PR DESCRIPTION
STDERR is used by amphp/parallel for error forwarding from children. STDERR gets written to the error log in case of Apache and similar locations for other SAPIs.

This also ensures STDOUT / STDERR can always be used and only a single stream ID exists for STDOUT / STDERR, which might otherwise error for libuv if people open 'php://stderr' multiple times.

Fixes amphp/parallel-functions#6.
Fixes amphp/parallel#34.