### PR TITLE
Add getStd*() functions

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2,6 +2,7 @@
 
 namespace Amp\ByteStream;
 
+use Amp\Loop;
 use Amp\Promise;
 use function Amp\call;
 
@@ -59,4 +60,61 @@ function buffer(InputStream $source): Promise
 
         return $buffer;
     });
+}
+
+/**
+ * The STDIN stream for the process associated with the currently active event loop.
+ *
+ * @return ResourceInputStream
+ */
+function getStdin(): ResourceInputStream
+{
+    static $key = InputStream::class . '\\stdin';
+
+    $stream = Loop::getState($key);
+
+    if (!$stream) {
+        $stream = new ResourceInputStream(\STDIN);
+        Loop::setState($key, $stream);
+    }
+
+    return $stream;
+}
+
+/**
+ * The STDOUT stream for the process associated with the currently active event loop.
+ *
+ * @return ResourceOutputStream
+ */
+function getStdout(): ResourceOutputStream
+{
+    static $key = OutputStream::class . '\\stdout';
+
+    $stream = Loop::getState($key);
+
+    if (!$stream) {
+        $stream = new ResourceOutputStream(\STDOUT);
+        Loop::setState($key, $stream);
+    }
+
+    return $stream;
+}
+
+/**
+ * The STDERR stream for the process associated with the currently active event loop.
+ *
+ * @return ResourceOutputStream
+ */
+function getStderr(): ResourceOutputStream
+{
+    static $key = OutputStream::class . '\\stderr';
+
+    $stream = Loop::getState($key);
+
+    if (!$stream) {
+        $stream = new ResourceOutputStream(\STDERR);
+        Loop::setState($key, $stream);
+    }
+
+    return $stream;
 }

--- a/test/StdStreamTest.php
+++ b/test/StdStreamTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Amp\ByteStream\Test;
+
+use Amp\ByteStream;
+use Amp\Loop;
+use Amp\PHPUnit\TestCase;
+
+class StdStreamTest extends TestCase
+{
+    public function testGetStdin()
+    {
+        Loop::run(function () {
+            $stream = ByteStream\getStdin();
+            $this->assertSame($stream, ByteStream\getStdin());
+            $this->assertSame(\STDIN, $stream->getResource());
+        });
+    }
+
+    public function testGetStdout()
+    {
+        Loop::run(function () {
+            $stream = ByteStream\getStdout();
+            $this->assertSame($stream, ByteStream\getStdout());
+            $this->assertSame(\STDOUT, $stream->getResource());
+        });
+    }
+
+    public function testGetStderr()
+    {
+        Loop::run(function () {
+            $stream = ByteStream\getStderr();
+            $this->assertSame($stream, ByteStream\getStderr());
+            $this->assertSame(\STDERR, $stream->getResource());
+        });
+    }
+}


### PR DESCRIPTION
Convenience functions to retrieve the STD* FDs as Amp streams. Will help avoid issues with creating multiple watchers on the same FD in loops where that's a problem.