### PR TITLE
Throw new exception carrying $chunk when fwrite returns 0

### DIFF
--- a/lib/CannotWriteChunkException.php
+++ b/lib/CannotWriteChunkException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Amp\ByteStream;
+
+final class CannotWriteChunkException extends StreamException
+{
+    /**
+     * @var string
+     */
+    private $chunk;
+
+    public function __construct(string $chunk, string $message = "", int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->chunk = $chunk;
+    }
+
+    public function getChunk(): string
+    {
+        return $this->chunk;
+    }
+}

--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -92,7 +92,7 @@ final class ResourceOutputStream implements OutputStream
                             if ($error = \error_get_last()) {
                                 $message .= \sprintf("; %s", $error["message"]);
                             }
-                            throw new StreamException($message);
+                            throw new CannotWriteChunkException($data, $message);
                         }
 
                         $writes->unshift([$data, $previous, $deferred]);


### PR DESCRIPTION
Fixes #51 

I tried hard to write a test for simulating such write failure, but any trick I tried, stream_select will not work with those. Another option would be to use unqualified fwrite call, but I don't think that would be approved.