### PR TITLE
Replace hard final with soft, annotation-based @final

### DIFF
--- a/lib/ResourceInputStream.php
+++ b/lib/ResourceInputStream.php
@@ -9,8 +9,10 @@ use Amp\Success;
 
 /**
  * Input stream abstraction for PHP's stream resources.
+ *
+ * @final
  */
-final class ResourceInputStream implements InputStream
+class ResourceInputStream implements InputStream
 {
     const DEFAULT_CHUNK_SIZE = 8192;
 

--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -10,8 +10,10 @@ use Amp\Success;
 
 /**
  * Output stream abstraction for PHP's stream resources.
+ *
+ * @final
  */
-final class ResourceOutputStream implements OutputStream
+class ResourceOutputStream implements OutputStream
 {
     const MAX_CONSECUTIVE_EMPTY_WRITES = 3;
     const LARGE_CHUNK_SIZE = 128 * 1024;

--- a/lib/ZlibInputStream.php
+++ b/lib/ZlibInputStream.php
@@ -7,8 +7,10 @@ use function Amp\call;
 
 /**
  * Allows decompression of input streams using Zlib.
+ *
+ * @final
  */
-final class ZlibInputStream implements InputStream
+class ZlibInputStream implements InputStream
 {
     private $source;
     private $encoding;

--- a/lib/ZlibOutputStream.php
+++ b/lib/ZlibOutputStream.php
@@ -6,8 +6,10 @@ use Amp\Promise;
 
 /**
  * Allows compression of output streams using Zlib.
+ *
+ * @final
  */
-final class ZlibOutputStream implements OutputStream
+class ZlibOutputStream implements OutputStream
 {
     private $destination;
     private $encoding;


### PR DESCRIPTION
I need to depend on ResourceOutputStream, because I rely on methods missing from interface. And I need to mock it for my tests. Hence I am proposing to drop hard `final` and replace it with annotation based `final`, which is same strategy Symfony follows. This gives you best from both worlds - you are still not obligated to keep an eye for inheritance based BC issues, but now people can mock it