### PR TITLE
Fix ResourceOutputStream closed detection

### DIFF
--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -71,7 +71,7 @@ final class ResourceOutputStream implements OutputStream
                         continue;
                     }
 
-                    if (!\is_resource($stream) || @\feof($stream)) {
+                    if (!\is_resource($stream)) {
                         throw new StreamException("The stream was closed by the peer");
                     }
 
@@ -87,6 +87,11 @@ final class ResourceOutputStream implements OutputStream
 
                     // Broken pipes between processes on macOS/FreeBSD do not detect EOF properly.
                     if ($written === 0) {
+                        $metaData = @\stream_get_meta_data($stream);
+                        if (!\is_resource($stream) || ($metaData && $metaData['eof'])) {
+                            throw new StreamException("The stream was closed by the peer");
+                        }
+
                         if ($emptyWrites++ > self::MAX_CONSECUTIVE_EMPTY_WRITES) {
                             $message = "Failed to write to stream after multiple attempts";
                             if ($error = \error_get_last()) {
@@ -179,7 +184,7 @@ final class ResourceOutputStream implements OutputStream
                 return new Success(0);
             }
 
-            if (!\is_resource($this->resource) || @\feof($this->resource)) {
+            if (!\is_resource($this->resource)) {
                 return new Failure(new StreamException("The stream was closed by the peer"));
             }
 

--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -71,7 +71,7 @@ final class ResourceOutputStream implements OutputStream
                         continue;
                     }
 
-                    if (!\is_resource($stream)) {
+                    if (!\is_resource($stream) || (($metaData = @\stream_get_meta_data($stream)) && $metaData['eof'])) {
                         throw new StreamException("The stream was closed by the peer");
                     }
 
@@ -87,11 +87,6 @@ final class ResourceOutputStream implements OutputStream
 
                     // Broken pipes between processes on macOS/FreeBSD do not detect EOF properly.
                     if ($written === 0) {
-                        $metaData = @\stream_get_meta_data($stream);
-                        if (!\is_resource($stream) || ($metaData && $metaData['eof'])) {
-                            throw new StreamException("The stream was closed by the peer");
-                        }
-
                         if ($emptyWrites++ > self::MAX_CONSECUTIVE_EMPTY_WRITES) {
                             $message = "Failed to write to stream after multiple attempts";
                             if ($error = \error_get_last()) {
@@ -184,8 +179,8 @@ final class ResourceOutputStream implements OutputStream
                 return new Success(0);
             }
 
-            if (!\is_resource($this->resource)) {
-                return new Failure(new StreamException("The stream was closed by the peer"));
+            if (!\is_resource($this->resource) || (($metaData = @\stream_get_meta_data($this->resource)) && $metaData['eof'])) {
+                throw new StreamException("The stream was closed by the peer");
             }
 
             // Error reporting suppressed since fwrite() emits E_WARNING if the pipe is broken or the buffer is full.

--- a/test/ResourceOutputStreamTest.php
+++ b/test/ResourceOutputStreamTest.php
@@ -44,7 +44,7 @@ class ResourceOutputStreamTest extends TestCase
         \fclose($b);
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessage("The stream was closed by the peer");
+        $this->expectExceptionMessage("Failed to write to stream after multiple attempts; fwrite(): send of 6 bytes failed with errno=32 Broken pipe");
         wait($stream->write("foobar"));
     }
 
@@ -60,7 +60,7 @@ class ResourceOutputStreamTest extends TestCase
         \fclose($b);
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessage("The stream was closed by the peer");
+        $this->expectExceptionMessage("Failed to write to stream after multiple attempts; fwrite(): send of 6 bytes failed with errno=32 Broken pipe");
 
         // The first write still succeeds somehow...
         wait($stream->write("foobar"));


### PR DESCRIPTION
The previous mechanism with feof doesn't work for systemd launched processes.

Fixes #58.