### PR TITLE
Fix ResourceInputStream not properly nulling the resource on close

### DIFF
--- a/lib/ResourceInputStream.php
+++ b/lib/ResourceInputStream.php
@@ -142,12 +142,12 @@ final class ResourceInputStream implements InputStream
                 Loop::cancel($this->watcher);
 
                 return new Success; // Stream closed, resolve read with null.
-            } else {
-                $this->deferred = new Deferred;
-                Loop::enable($this->watcher);
-
-                return $this->deferred->promise();
             }
+
+            $this->deferred = new Deferred;
+            Loop::enable($this->watcher);
+
+            return $this->deferred->promise();
         }
 
         // Prevent an immediate read → write loop from blocking everything


### PR DESCRIPTION
This causes the stream to be reported as open by amphp/socket, which in
turn causes InvalidWatcherErrors in amphp/http-client, because the
socket is reported as still open and thus referenced.

Fixes #67.