### PR TITLE
Prevent infinite loop on writing to broken pipes

### DIFF
--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -85,8 +85,8 @@ final class ResourceOutputStream implements OutputStream
 
                     \assert($written !== false, "Trying to write on a previously fclose()'d resource. Do NOT manually fclose() resources the loop still has a reference to.");
 
-                    // Broken pipes between processes on macOS/FreeBSD do not detect EOF properly.
-                    if ($written === 0) {
+                    // Broken pipes between processes on macOS/FreeBSD (and probably Docker) do not detect EOF properly.
+                    if ($written === 0 || $written === false) {
                         if ($emptyWrites++ > self::MAX_CONSECUTIVE_EMPTY_WRITES) {
                             $message = "Failed to write to stream after multiple attempts";
                             if ($error = \error_get_last()) {


### PR DESCRIPTION
The assertion `"Trying to write on a previously fclose()'d resource. Do NOT manually fclose() resources the loop still has a reference to."` happens to me even if I have not a single `fclose()`, `stream_XXX()` or `socket_XXX()` call in my code.

My client and server thin wrappers around `Server::listen()` and `connect()` are running with Docker containers on Windows. So it might be related to docker networking internals, breaking sockets under some circumstances.

It happens occassionaly. I spent a whole day to find steps to reproduce it with no luck. 

Anyway, since the case does really happen sometimes in runtime, I think it would be better to handle it and prevent the infinite loop. 