### PR TITLE
Iterator Stream documentation

### DIFF
--- a/docs/iterator-stream.md
+++ b/docs/iterator-stream.md
@@ -10,5 +10,5 @@ $inputStream = new IteratorStream(new Producer(function (callable $emit) {
         yield new Delayed(1000);
         yield $emit(".");
     }
-});
+}));
 ```


### PR DESCRIPTION
Missing parenthesis in [example](https://github.com/amphp/byte-stream/blob/7a64a9ad336fc5e1e70b1c1fc1e9618a7027332e/docs/iterator-stream.md).