### PR TITLE
Fix psalm annotation

### DIFF
--- a/lib/IteratorStream.php
+++ b/lib/IteratorStream.php
@@ -17,7 +17,7 @@ final class IteratorStream implements InputStream
     private $pending = false;
 
     /**
-     * @psam-param Iterator<string> $iterator
+     * @psalm-param Iterator<string> $iterator
      */
     public function __construct(Iterator $iterator)
     {


### PR DESCRIPTION
Constructor has invalid annotation. My IDE have indexed this annotation and adds it to autocomplete. 
So i also have few invalid annotations in my code:)

```
    /**
     * @psam-param Iterator<string> $iterator
     */
    public function __construct(Iterator $iterator)
    {
        $this->iterator = $iterator;
    }
```