### PR TITLE
Fix read watcher staying active in StreamChannel

### DIFF
--- a/src/StreamChannel.php
+++ b/src/StreamChannel.php
@@ -28,6 +28,7 @@ final class StreamChannel implements Channel
 
     private ChannelParser $parser;
 
+    /** @var \SplQueue<TReceive> */
     private \SplQueue $received;
 
     private Mutex $readMutex;

--- a/src/StreamChannel.php
+++ b/src/StreamChannel.php
@@ -4,9 +4,6 @@ namespace Amp\ByteStream;
 
 use Amp\ByteStream\Internal\ChannelParser;
 use Amp\Cancellation;
-use Amp\DeferredFuture;
-use Amp\Pipeline\ConcurrentIterator;
-use Amp\Pipeline\Pipeline;
 use Amp\Serialization\Serializer;
 use Amp\Sync\Channel;
 use Amp\Sync\ChannelException;
@@ -28,11 +25,7 @@ final class StreamChannel implements Channel
 
     private ChannelParser $parser;
 
-    /** @var ConcurrentIterator<TReceive> */
-    private ConcurrentIterator $iterator;
-
-    private int $pendingReceives = 0;
-    private ?DeferredFuture $readBarrier = null;
+    private \SplQueue $received;
 
     /**
      * Creates a new channel from the given stream objects. Note that $read and $write can be the same object.
@@ -42,52 +35,22 @@ final class StreamChannel implements Channel
         $this->read = $read;
         $this->write = $write;
 
-        $readBarrier = &$this->readBarrier;
-        $pendingReceives = &$this->pendingReceives;
-
-        $received = new \SplQueue();
-        $this->parser = $parser = new ChannelParser(\Closure::fromCallable([$received, 'push']), $serializer);
-
-        $this->iterator = Pipeline::fromIterable(static function () use (
-            $read,
-            $received,
-            $parser,
-            &$readBarrier,
-            &$pendingReceives,
-        ): \Generator {
-            while (true) {
-                if ($pendingReceives === 0) {
-                    $readBarrier = new DeferredFuture();
-                    $readBarrier->getFuture()->await();
-                }
-
-                try {
-                    $chunk = $read->read();
-                } catch (StreamException $exception) {
-                    throw new ChannelException(
-                        "Reading from the channel failed. Did the context die?",
-                        0,
-                        $exception,
-                    );
-                }
-
-                if ($chunk === null) {
-                    throw new ChannelException("The channel closed while waiting to receive the next value");
-                }
-
-                $parser->push($chunk);
-
-                while (!$received->isEmpty()) {
-                    $pendingReceives--;
-                    yield $received->shift();
-                }
-            }
-        })->getIterator();
+        $this->received = new \SplQueue();
+        $this->parser = new ChannelParser($this->received->push(...), $serializer);
     }
 
     public function __destruct()
     {
         $this->close();
+    }
+
+    /**
+     * Closes the read and write resource streams.
+     */
+    public function close(): void
+    {
+        $this->read->close();
+        $this->write->close();
     }
 
     public function send(mixed $data): void
@@ -103,30 +66,32 @@ final class StreamChannel implements Channel
 
     public function receive(?Cancellation $cancellation = null): mixed
     {
-        if (++$this->pendingReceives === 1) {
-            $this->readBarrier?->complete();
-            $this->readBarrier = null;
+        $cancellation?->throwIfRequested();
+
+        while ($this->received->isEmpty()) {
+            try {
+                $chunk = $this->read->read($cancellation);
+            } catch (StreamException $exception) {
+                throw new ChannelException(
+                    "Reading from the channel failed. Did the context die?",
+                    0,
+                    $exception,
+                );
+            }
+
+            if ($chunk === null) {
+                throw new ChannelException("The channel closed while waiting to receive the next value");
+            }
+
+            $this->parser->push($chunk);
         }
 
-        if (!$this->iterator->continue($cancellation)) {
-            throw new ChannelException("The channel closed while waiting to receive the next value");
-        }
-
-        return $this->iterator->getValue();
+        return $this->received->shift();
     }
 
     public function isClosed(): bool
     {
         return $this->read->isClosed() || $this->write->isClosed();
-    }
-
-    /**
-     * Closes the read and write resource streams.
-     */
-    public function close(): void
-    {
-        $this->read->close();
-        $this->write->close();
     }
 
     public function onClose(\Closure $onClose): void

--- a/test/StreamChannelTest.php
+++ b/test/StreamChannelTest.php
@@ -21,6 +21,20 @@ class StreamChannelTest extends AsyncTestCase
         $this->assertSame($message, $data);
     }
 
+    public function testSendReceiveBuffered(): void
+    {
+        $pipe = new Pipe(10000);
+        $channel = new StreamChannel($pipe->getSource(), $pipe->getSink());
+
+        $message = 'hello';
+        $encoded = \serialize($message);
+        $encoded = \pack('CL', 0, \strlen($encoded)) . $encoded;
+
+        $pipe->getSink()->write($encoded . $encoded);
+        $data = $channel->receive();
+        $this->assertSame($message, $data);
+    }
+
     /**
      * @depends testSendReceive
      */

--- a/test/StreamChannelTest.php
+++ b/test/StreamChannelTest.php
@@ -5,6 +5,7 @@ namespace Amp\ByteStream;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Serialization\SerializationException;
 use Amp\Sync\ChannelException;
+use function Amp\async;
 
 class StreamChannelTest extends AsyncTestCase
 {
@@ -15,7 +16,7 @@ class StreamChannelTest extends AsyncTestCase
 
         $message = 'hello';
 
-        $channel->send($message);
+        async(fn () => $channel->send($message));
         $data = $channel->receive();
         $this->assertSame($message, $data);
     }
@@ -34,7 +35,7 @@ class StreamChannelTest extends AsyncTestCase
             $message .= \chr(\mt_rand(0, 255));
         }
 
-        $channel->send($message);
+        async(fn () => $channel->send($message));
         $data = $channel->receive();
         $this->assertSame($message, $data);
     }
@@ -51,7 +52,7 @@ class StreamChannelTest extends AsyncTestCase
         $channel = new StreamChannel($pipe->getSource(), $sink);
 
         // Close $a. $b should close on next read...
-        $sink->write(\pack('L', 10) . '1234567890');
+        async(fn () => $sink->write(\pack('L', 10) . '1234567890'));
         $data = $channel->receive();
     }
 


### PR DESCRIPTION
See https://github.com/amphp/file/issues/69. Caused by the stream channel of amphp/parallel.