### PR TITLE
Fix invalid use for ConcurrentIterableIterator

### DIFF
--- a/src/ReadableIterableStream.php
+++ b/src/ReadableIterableStream.php
@@ -5,7 +5,6 @@ namespace Amp\ByteStream;
 use Amp\Cancellation;
 use Amp\CancelledException;
 use Amp\DeferredFuture;
-use Amp\Pipeline\Internal\ConcurrentIterableIterator;
 use Amp\Pipeline\ConcurrentIterator;
 use Amp\Pipeline\Pipeline;
 
@@ -30,14 +29,9 @@ final class ReadableIterableStream implements ReadableStream
      */
     public function __construct(iterable $iterable)
     {
-        /** @psalm-suppress TypeDoesNotContainType */
-        if ($iterable instanceof Pipeline) {
-            $iterable = $iterable->getIterator();
-        }
-
         $this->iterator = $iterable instanceof ConcurrentIterator
             ? $iterable
-            : new ConcurrentIterableIterator($iterable);
+            : Pipeline::fromIterable($iterable)->getIterator();
 
         $this->onClose = new DeferredFuture;
     }

--- a/src/ReadableIterableStream.php
+++ b/src/ReadableIterableStream.php
@@ -5,7 +5,7 @@ namespace Amp\ByteStream;
 use Amp\Cancellation;
 use Amp\CancelledException;
 use Amp\DeferredFuture;
-use Amp\Pipeline\ConcurrentIterableIterator;
+use Amp\Pipeline\Internal\ConcurrentIterableIterator;
 use Amp\Pipeline\ConcurrentIterator;
 use Amp\Pipeline\Pipeline;
 

--- a/test/ReadableIterableStreamTest.php
+++ b/test/ReadableIterableStreamTest.php
@@ -90,18 +90,19 @@ final class ReadableIterableStreamTest extends AsyncTestCase
         }
     }
 
-    public function testPhpEngineIterables(): void {
-        $iterables = [
-            ['abc'],
-            new \ArrayIterator(['abc']),
-            (static function () {
-                yield 'abc';
-            })()
-        ];
+    public function provideEngineIterables(): iterable
+    {
+        yield 'array' => [['abc']];
+        yield 'iterator' => [new \ArrayIterator(['abc'])];
+        yield 'generator' => [(static fn () => yield 'abc')()];
+    }
 
-        foreach ($iterables as $iterable) {
-            $stream = new ReadableIterableStream($iterable);
-            self::assertSame($stream->read(), 'abc');
-        }
+    /**
+     * @dataProvider provideEngineIterables
+     */
+    public function testPhpEngineIterables(iterable $iterable): void
+    {
+        $stream = new ReadableIterableStream($iterable);
+        self::assertSame($stream->read(), 'abc');
     }
 }

--- a/test/ReadableIterableStreamTest.php
+++ b/test/ReadableIterableStreamTest.php
@@ -89,4 +89,19 @@ final class ReadableIterableStreamTest extends AsyncTestCase
             $stream->read();
         }
     }
+
+    public function testPhpEngineIterables(): void {
+        $iterables = [
+            ['abc'],
+            new \ArrayIterator(['abc']),
+            (static function () {
+                yield 'abc';
+            })()
+        ];
+
+        foreach ($iterables as $iterable) {
+            $stream = new ReadableIterableStream($iterable);
+            self::assertSame($stream->read(), 'abc');
+        }
+    }
 }


### PR DESCRIPTION
Also added the test for php engine iterables. The exception was not caught in tests because instance of ConcurrentIterableIterator was always passed to ReadableIterableStream constructor in tests and never hit the branch for other type of iterables.