### PR TITLE
do not use stream_socket_shutdown

### DIFF
--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -242,12 +242,7 @@ final class ReadableResourceStream implements ReadableStream, ResourceStream, \I
         if (\is_resource($this->resource) && \get_resource_type($this->resource) === 'stream') {
             $meta = \stream_get_meta_data($this->resource);
 
-            if (\str_contains($meta["mode"], "+")) {
-                \stream_socket_shutdown($this->resource, \STREAM_SHUT_RD);
-            } else {
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
-                \fclose($this->resource);
-            }
+            \fclose($this->resource);
         }
 
         $this->suspension?->resume();

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -153,11 +153,7 @@ final class WritableResourceStream implements WritableStream, ResourceStream
                 } finally {
                     if (!$writable && \is_resource($resource)) {
                         $meta = \stream_get_meta_data($resource);
-                        if (\str_contains($meta["mode"], "+")) {
-                            \stream_socket_shutdown($resource, \STREAM_SHUT_WR);
-                        } else {
-                            \fclose($resource);
-                        }
+                        \fclose($resource);
                         $resource = null;
                     }
 
@@ -272,12 +268,7 @@ final class WritableResourceStream implements WritableStream, ResourceStream
             // Error suppression, as resource might already be closed
             $meta = \stream_get_meta_data($this->resource);
 
-            if (\str_contains($meta["mode"], "+")) {
-                \stream_socket_shutdown($this->resource, \STREAM_SHUT_WR);
-            } else {
-                /** @psalm-suppress InvalidPropertyAssignmentValue psalm reports this as closed-resource */
-                \fclose($this->resource);
-            }
+            \fclose($this-resource);
         }
 
         $this->free();


### PR DESCRIPTION
If a PHP process is sharing a file-descriptor with another process/thread, the file-descriptor will be closed for every other process/thread using that descriptor -- when using `stream_socket_shutdown` and causes broken pipes. At least in Linux, this *should not* happen, instead, the OS maintains a list of listeners/writers and will only break the pipe once all listeners are gone. `fclose` respects this and doesn't forcibly close the pipe for all users of the pipe.

This is especially important when accepting sockets and handing them off to another process (think CGI) and then closing the PHP side.

closes #105 