### PR TITLE
Return closed stream if STDIO stream is closed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
             "Amp\\ByteStream\\": "src"
         },
         "files": [
-            "src/functions.php"
+            "src/functions.php",
+            "src/Internal/functions.php"
         ]
     },
     "autoload-dev": {

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Amp\ByteStream\Internal;
+
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\WritableResourceStream;
+
+/**
+ * @internal
+ * @param resource $resource Stream resource.
+ */
+function tryToCreateReadableStreamFromResource($resource): ReadableResourceStream
+{
+    return \is_resource($resource) && \get_resource_type($resource) === 'stream'
+        ? new ReadableResourceStream($resource)
+        : new ReadableResourceStream(\fopen('php://memory', 'rb'));
+}
+
+/**
+ * @internal
+ * @param resource $resource Stream resource.
+ */
+function tryToCreateWritableStreamFromResource($resource): WritableResourceStream
+{
+    if (\is_resource($resource) && \get_resource_type($resource) === 'stream') {
+        return new WritableResourceStream($resource);
+    }
+
+    $stream = new WritableResourceStream(\fopen('php://memory', 'wb'));
+    $stream->close();
+
+    return $stream;
+}

--- a/src/Internal/functions.php
+++ b/src/Internal/functions.php
@@ -11,9 +11,14 @@ use Amp\ByteStream\WritableResourceStream;
  */
 function tryToCreateReadableStreamFromResource($resource): ReadableResourceStream
 {
-    return \is_resource($resource) && \get_resource_type($resource) === 'stream'
-        ? new ReadableResourceStream($resource)
-        : new ReadableResourceStream(\fopen('php://memory', 'rb'));
+    if (\is_resource($resource) && \get_resource_type($resource) === 'stream') {
+        return new ReadableResourceStream($resource);
+    }
+
+    $stream = new ReadableResourceStream(\fopen('php://memory', 'rb'));
+    $stream->close();
+
+    return $stream;
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -92,7 +92,7 @@ function getStdin(): ReadableResourceStream
 
     $map ??= new \WeakMap();
 
-    return $map[EventLoop::getDriver()] ??= new ReadableResourceStream(\STDIN);
+    return $map[EventLoop::getDriver()] ??= Internal\tryToCreateReadableStreamFromResource(\STDIN);
 }
 
 /**
@@ -104,7 +104,7 @@ function getStdout(): WritableResourceStream
 
     $map ??= new \WeakMap();
 
-    return $map[EventLoop::getDriver()] ??= new WritableResourceStream(\STDOUT);
+    return $map[EventLoop::getDriver()] ??= Internal\tryToCreateWritableStreamFromResource(\STDOUT);
 }
 
 /**
@@ -116,7 +116,7 @@ function getStderr(): WritableResourceStream
 
     $map ??= new \WeakMap();
 
-    return $map[EventLoop::getDriver()] ??= new WritableResourceStream(\STDERR);
+    return $map[EventLoop::getDriver()] ??= Internal\tryToCreateWritableStreamFromResource(\STDERR);
 }
 
 /**


### PR DESCRIPTION
This modifies `getStdin()`, `getStdout()`, and `getStderr()` to return an already closed stream if the corresponding resource has been previously closed.