### PR TITLE
Add explicit nullable types

### DIFF
--- a/lib/InMemoryStream.php
+++ b/lib/InMemoryStream.php
@@ -15,7 +15,7 @@ final class InMemoryStream implements InputStream
     /**
      * @param string|null $contents Data chunk or `null` for no data chunk.
      */
-    public function __construct(string $contents = null)
+    public function __construct(?string $contents = null)
     {
         $this->contents = $contents;
     }

--- a/lib/LineReader.php
+++ b/lib/LineReader.php
@@ -19,7 +19,7 @@ final class LineReader
     /** @var InputStream */
     private $source;
 
-    public function __construct(InputStream $inputStream, string $delimiter = null)
+    public function __construct(InputStream $inputStream, ?string $delimiter = null)
     {
         $this->source = $inputStream;
         $this->delimiter = $delimiter === null ? "\n" : $delimiter;

--- a/lib/PendingReadError.php
+++ b/lib/PendingReadError.php
@@ -10,7 +10,7 @@ final class PendingReadError extends \Error
     public function __construct(
         string $message = "The previous read operation must complete before read can be called again",
         int $code = 0,
-        \Throwable $previous = null
+        ?\Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/ResourceOutputStream.php
+++ b/lib/ResourceOutputStream.php
@@ -35,7 +35,7 @@ final class ResourceOutputStream implements OutputStream
      * @param resource $stream Stream resource.
      * @param int|null $chunkSize Chunk size per `fwrite()` operation.
      */
-    public function __construct($stream, int $chunkSize = null)
+    public function __construct($stream, ?int $chunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== 'stream') {
             throw new \Error("Expected a valid stream");


### PR DESCRIPTION
This is a requirement to be deprecation free in PHP 8.4, related to https://github.com/symfony/symfony/issues/54180