### PR TITLE
Use consistent key in split

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -131,7 +131,6 @@ function getStderr(): WritableResourceStream
 function split(ReadableStream $source, string $delimiter, ?Cancellation $cancellation = null): \Traversable
 {
     $buffer = '';
-    $k = 0;
 
     while (null !== $chunk = $source->read($cancellation)) {
         $buffer .= $chunk;
@@ -139,13 +138,14 @@ function split(ReadableStream $source, string $delimiter, ?Cancellation $cancell
         $split = \explode($delimiter, $buffer);
         $buffer = \array_pop($split);
 
+        // Don't use yield from to avoid reusing the keys from $split
         foreach ($split as $v) {
-            yield $k++ => $v;
+            yield $v;
         }
     }
 
     if ($buffer !== '') {
-        yield $k => $buffer;
+        yield $buffer;
     }
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -131,6 +131,7 @@ function getStderr(): WritableResourceStream
 function split(ReadableStream $source, string $delimiter, ?Cancellation $cancellation = null): \Traversable
 {
     $buffer = '';
+    $k = 0;
 
     while (null !== $chunk = $source->read($cancellation)) {
         $buffer .= $chunk;
@@ -138,11 +139,13 @@ function split(ReadableStream $source, string $delimiter, ?Cancellation $cancell
         $split = \explode($delimiter, $buffer);
         $buffer = \array_pop($split);
 
-        yield from $split;
+        foreach ($split as $v) {
+            yield $k++ => $v;
+        }
     }
 
     if ($buffer !== '') {
-        yield $buffer;
+        yield $k => $buffer;
     }
 }
 

--- a/test/SplitTest.php
+++ b/test/SplitTest.php
@@ -58,6 +58,20 @@ final class SplitTest extends AsyncTestCase
         $this->check(["a", "bc", "\r", "\n\r\nef\r", "\n"], ["abc", "", "ef"]);
     }
 
+    public function testKey(): void
+    {
+        $stream = new ReadableIterableStream(Pipeline::fromIterable(["a|b|c", "|", "||d|e|f"]));
+
+        $lines = [];
+        $expectedK = 0;
+        foreach (split($stream, '|') as $k => $line) {
+            $this->assertEquals($expectedK++, $k);
+            $lines[] = $line;
+        }
+
+        self::assertSame(["a", "b", "c", "", "", "d", "e", "f"], $lines);
+    }
+
     public function testCustomDelimiter(): void
     {
         $stream = new ReadableIterableStream(Pipeline::fromIterable(["a|b|c", "|", "||d|e|f"]));


### PR DESCRIPTION
Reliance on the key is useful in some conditions, and the non-monotonicity of the key caused a very nasty bug in our code.
